### PR TITLE
Pass current loopback user id into credentials functions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,11 +5,11 @@ const passport = require('passport');
 const logger = require('oniyi-logger')('oniyi:http-client:plugin:attach-credentials');
 
 
-function areCredentialsExpired(credentials, callback) {
+function areCredentialsExpired(userId, credentials, callback) {
   return callback(null, credentials.expiresAt && credentials.expiresAt < Date.now());
 }
 
-function refreshCredentials(strategy, currentCredentials, callback) {
+function refreshCredentials(strategy, userId, currentCredentials, callback) {
   const params = { grant_type: 'refresh_token' };
   // eslint-disable-next-line no-underscore-dangle
   strategy._oauth2.getOAuthAccessToken(currentCredentials.refreshToken, params,
@@ -124,7 +124,7 @@ module.exports = function attachCredentialsPluginFactory(pluginOptions) {
         // must handle credentials refresh in pre-flight phase due to possible use of stream API
         // with request. If client wants to send data, we can not ensure that data is still available
         // when retrying.
-        options.areCredentialsExpired(credentials, (expiredErr, credentialsExpired) => {
+        options.areCredentialsExpired(user.id, credentials, (expiredErr, credentialsExpired) => {
           if (expiredErr) {
             return callback(expiredErr);
           }
@@ -138,7 +138,7 @@ module.exports = function attachCredentialsPluginFactory(pluginOptions) {
               throw new Error(`Auth provider with name "${options.providerName}" is not registered`);
             }
 
-            return options.refreshCredentials(strategy, credentials, (refreshCredentialsErr, newCredentials) => {
+            return options.refreshCredentials(strategy, user.id, credentials, (refreshCredentialsErr, newCredentials) => {
               if (refreshCredentialsErr) {
                 return callback(refreshCredentialsErr);
               }


### PR DESCRIPTION
This would greatly aid me in a current use case I have where Im storing the
actual credentials in redis and I look them up by user id. Or rather, I would
like to be able to look them up by user id but in order to do that I need to have
access to the current user id in the credentials functions.