### PR TITLE
Ensure userId exists on the credentials object

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -121,6 +121,10 @@ module.exports = function attachCredentialsPluginFactory(pluginOptions) {
           return callback(null, origParams);
         }
 
+        if (!credentials.userId) {
+          Object.assign(credentials, { userId: user.id });
+        }
+
         // must handle credentials refresh in pre-flight phase due to possible use of stream API
         // with request. If client wants to send data, we can not ensure that data is still available
         // when retrying.


### PR DESCRIPTION
Hi @benkroeger! Me again 😃 

This is a non-breaking version of the change I would like to make.

Doesn't change function contracts. Simply ensures the presence of a userId in the credentials object.

What do you think?